### PR TITLE
Album: change json field for TotalMediaItems

### DIFF
--- a/api/photoslibrary/v1/photoslibrary-patched.go
+++ b/api/photoslibrary/v1/photoslibrary-patched.go
@@ -241,7 +241,7 @@ type Album struct {
 	Title string `json:"title,omitempty"`
 
 	// TotalMediaItems: [Output only] The number of media items in the album
-	TotalMediaItems int64 `json:"totalMediaItems,omitempty,string"`
+	TotalMediaItems int64 `json:"mediaItemsCount,omitempty,string"`
 
 	// ServerResponse contains the HTTP response code and headers from the
 	// server.


### PR DESCRIPTION
It's actually mediaItemsCount -- not sure if this changed, but there definitely
isn't a `totalMediaItems` field in the response [1]

I didn't change the actual struct member in case others use this library, and
to avoid a version bump.

[1] https://developers.google.com/photos/library/reference/rest/v1/albums

Signed-off-by: Kelvie Wong <kelvie@kelvie.ca>