### PR TITLE
Add support for photoslibrary.albums.batchAddMediaItems

### DIFF
--- a/api/photoslibrary/v1/photoslibrary-patched.go
+++ b/api/photoslibrary/v1/photoslibrary-patched.go
@@ -399,6 +399,64 @@ func (s *BatchCreateMediaItemsResponse) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+// AlbumBatchAddMediaItemsRequest: Request to add one or more existing media
+// items to an existing Album.
+type AlbumBatchAddMediaItemsRequest struct {
+	// MediaItemIds: List of media items to be add to the album above.
+	MediaItemIds []string `json:"mediaItemIds,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "AlbumId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AlbumId") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AlbumBatchAddMediaItemsRequest) MarshalJSON() ([]byte, error) {
+	type NoMethod AlbumBatchAddMediaItemsRequest
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type AlbumBatchAddMediaItemsResponse struct {
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "NewMediaItemResults")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "NewMediaItemResults") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AlbumBatchAddMediaItemsResponse) MarshalJSON() ([]byte, error) {
+	type NoMethod AlbumBatchAddMediaItemsResponse
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
 // ContentFilter: This filter is used to define which results to return
 // based on the contents
 // of the media item.
@@ -2571,6 +2629,147 @@ func (c *AlbumsShareCall) Do(opts ...googleapi.CallOption) (*ShareAlbumResponse,
 	//     "$ref": "ShareAlbumResponse"
 	//   },
 	//   "scopes": [
+	//     "https://www.googleapis.com/auth/photoslibrary.sharing"
+	//   ]
+	// }
+
+}
+
+// method id "photoslibrary.albums.batchAddMediaItems":
+
+type AlbumBatchAddMediaItemsCall struct {
+	s                              *Service
+	albumbatchaddmediaitemsrequest *AlbumBatchAddMediaItemsRequest
+	albumId                        string
+	urlParams_                     gensupport.URLParams
+	ctx_                           context.Context
+	header_                        http.Header
+}
+
+// BatchAddMediaItems: Adds existing media items to an existing album.
+// The maximum number of media items that can be added in one call is 50.
+func (r *AlbumsService) BatchAddMediaItems(albumId string, albumbatchaddmediaitemsrequest *AlbumBatchAddMediaItemsRequest) *AlbumBatchAddMediaItemsCall {
+	c := &AlbumBatchAddMediaItemsCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.albumbatchaddmediaitemsrequest = albumbatchaddmediaitemsrequest
+	c.albumId = albumId
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *AlbumBatchAddMediaItemsCall) Fields(s ...googleapi.Field) *AlbumBatchAddMediaItemsCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *AlbumBatchAddMediaItemsCall) Context(ctx context.Context) *AlbumBatchAddMediaItemsCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *AlbumBatchAddMediaItemsCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *AlbumBatchAddMediaItemsCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.albumbatchaddmediaitemsrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/albums/{+albumId}:batchAddMediaItems")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"albumId": c.albumId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "photoslibrary.albums.batchAddMediaItems" call.
+// Exactly one of *AlbumBatchAddMediaItemsResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *AlbumBatchAddMediaItemsResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *AlbumBatchAddMediaItemsCall) Do(opts ...googleapi.CallOption) (*AlbumBatchAddMediaItemsResponse, error) {
+
+	// TODO: There's a limit of 50 mediaitems per call. Split in multiple calls if more are provided.
+
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &AlbumBatchAddMediaItemsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Adds existing media items to an existing album.",
+	//   "flatPath": "v1/albums/{albumId}:batchAddMediaItems",
+	//   "httpMethod": "POST",
+	//   "id": "photoslibrary.albums.batchAddMediaItems",
+	//   "parameterOrder": [
+	//     "albumId"
+	//   ],
+	//   "parameters": {
+	//     "albumId": {
+	//       "description": "Identifier of the album to be added to.\n.",
+	//       "location": "path",
+	//       "pattern": "^[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/albums/{albumId}:batchAddMediaItems",
+	//   "request": {
+	//     "$ref": "AlbumBatchAddMediaItemsRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "AlbumBatchAddMediaItemsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/photoslibrary",
+	//     "https://www.googleapis.com/auth/photoslibrary.appendonly",
 	//     "https://www.googleapis.com/auth/photoslibrary.sharing"
 	//   ]
 	// }


### PR DESCRIPTION
Allows you to add MediaItems to an Album.

API reference page: https://developers.google.com/photos/library/reference/rest/v1/albums/batchAddMediaItems